### PR TITLE
Updated the license, and stubbed in a readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,29 @@
-Copyright (c) Greg Sebastian and Adam Valair and individual contributors.
+BSD 3-Clause License
+
+Copyright (c) 2017, Greg Sebastian and Adam Valair.
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-    3. Neither the name of Django nor the names of its contributors may be used
-       to endorse or promote products derived from this software without
-       specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# python-geomark
+# Python Geomark
+
+A small python library that provides implementations of the BC Governments [Geomark Web Service]
+
+## Installation
+
+TODO: Describe the installation process
+
+## Usage
+
+TODO: Write usage instructions
+
+## Testing
+
+### Using tox
+
+The recommended way to run the tests is by using [tox], which can be installed
+using`pip install tox`.
+
+You can use `tox -l` to list the available environments, and then e.g. use
+the following to run all tests with Python 3.6
+
+```
+    tox -e py36
+```
+
+### Running tests manually
+
+Please refer to the [tox.ini] file for reference/help in case you want to run
+tests manually / without tox.
+
+## Contributing
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## History
+
+TODO: Write history
+
+## Credits
+
+- [Adam Valaire](https://github.com/spatialbits) (Primary Developer/Maintainer)
+- [Greg Sebastian](https://github.com/gregseb) (Primary Developer/Maintainer)
+
+## License
+
+This project is licensed under the BSD 3-Clause License - see the [LICENSE] file for details
+
+[Geomark Web Service]: https://www2.gov.bc.ca/gov/content/data/geographic-data-services/location-services/geomark-webservice
+[tox]: https://tox.readthedocs.io/en/latest/
+
+[tox.ini]: tox.ini
+[LICENSE]: LICENSE

--- a/python_geomark.egg-info/SOURCES.txt
+++ b/python_geomark.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+.coveragerc
 .gitignore
 .travis.yml
 LICENSE
@@ -6,6 +7,7 @@ README.md
 __init__.py
 requirements.txt
 setup.py
+tox.ini
 geomark/__init__.py
 geomark/geomark.py
 python_geomark.egg-info/PKG-INFO


### PR DESCRIPTION
- Updated the license to use Github's BSD 3-Clause template, and added the year.
- Stubbed in the README, based on the template found [here](https://gist.github.com/zenorocha/4526327)
- Added sections to readme on testing (based on [django-rest-framework-gis](https://github.com/djangonauts/django-rest-framework-gis/blob/master/README.rst#using-tox)) and a blurb about the license.

Fixes #1 